### PR TITLE
ci: ignore alloy major dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "alloy*"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Ignore Dependabot semver-major updates for `alloy*` in the Cargo update block.
- Keep Alloy minor/patch updates eligible.
- Leave a coordinated Alloy 2.x upgrade for a separate task instead of partially upgrading signing/runtime dependencies.

## Verification
- PR #12 fails in Cargo Check, after Rustfmt passes.
- The failure is in registry source `alloy-dyn-abi-1.5.7/src/coerce.rs`, not EVPOLY `src/`.
- Scratch worktree cargo tree shows a mixed Alloy stack: root `alloy-contract v2.0.4`, while `alloy v1.8.3` still brings `alloy-contract v1.8.3`, `alloy-core v1.5.7`, and `alloy-dyn-abi v1.5.7`.
- `winnow@0.7.15` is pulled by `alloy-dyn-abi v1.5.7`; `winnow@1.0.2` is also present through the newer Alloy parser path.

## Coordinated Alloy 2.x upgrade task
Do this separately from Dependabot noise suppression:
1. Upgrade the whole Alloy stack together: `alloy`, `alloy-contract`, `alloy-dyn-abi`, `alloy-sol-types`, `alloy-primitives`, `alloy-provider`, `alloy-signer*`, `alloy-rpc-*`, `alloy-network`, and `alloy-transport*`.
2. Include Alloy pins/usages under `vendor-polymarket-client-sdk/`.
3. Fix 2.x API changes conservatively, especially signing, contract calls, and on-chain redeem/merge/approve calldata in `src/api.rs`.
4. Re-run the full locked cargo gates and security audit.

## Gates
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `cargo test --locked --all-targets`
- `./scripts/security_audit.sh`