### PR TITLE
ci: update node-based actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   rust:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Rustfmt

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout desktop tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -40,12 +40,12 @@ jobs:
 
     steps:
       - name: Checkout desktop tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary
- Update Node-based workflow actions to v5.
- Replace `actions/checkout@v4` with `actions/checkout@v5`.
- Replace `actions/setup-node@v4` with `actions/setup-node@v5`.

## Verification
- Verified current CI logs warn that Node 20 actions are forced onto Node 24.
- Verified upstream v5 tags exist for both actions.
- Confirmed no `actions/checkout@v4` or `actions/setup-node@v4` references remain under `.github/workflows/`.
- Desktop workflow keeps explicit `cache: npm` configuration.

## Gates
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `cargo test --locked --all-targets`
- `./scripts/security_audit.sh`