### PR TITLE
ci: update desktop node-based actions

### DIFF
--- a/.github/workflows/desktop-preflight.yml
+++ b/.github/workflows/desktop-preflight.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout desktop repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout desktop repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Checkout desktop repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout desktop repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
@@ -40,12 +40,12 @@ jobs:
 
     steps:
       - name: Checkout desktop repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Summary
- Update live desktop release/preflight workflow actions to Node 24-compatible majors.
- Replace `actions/checkout@v4` with `actions/checkout@v5`.
- Replace `actions/setup-node@v4` with `actions/setup-node@v5`.
- Leave all `node-version:` inputs unchanged.

## Verification
- `actionlint` is not installed locally.
- Confirmed diff is only action major bumps in `.github/workflows/release.yml` and `.github/workflows/desktop-preflight.yml`.
- `rg -n checkout@v4|setup-node@v4 .github/workflows/` returns no matches locally on this branch.