### PR TITLE
Release runtime v2.5.2

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,17 +8,17 @@
 [advisories]
 informational_warnings = ["unmaintained", "unsound", "notice"]
 ignore = [
-  # expires: 2026-06-30 id: RUSTSEC-2026-0037 reason: quinn-proto is present in Cargo.lock; cargo tree -i quinn-proto --target all reports no active dependency path.
+  # expires: 2026-07-31 id: RUSTSEC-2026-0037 reason: quinn-proto is present in Cargo.lock; cargo tree -i quinn-proto --target all reports no active dependency path.
   "RUSTSEC-2026-0037",
-  # expires: 2026-06-30 id: RUSTSEC-2025-0012 reason: transitive in polymarket-client-sdk; awaiting upstream migration off backoff.
+  # expires: 2026-07-31 id: RUSTSEC-2025-0012 reason: transitive in polymarket-client-sdk; awaiting upstream migration off backoff.
   "RUSTSEC-2025-0012",
-  # expires: 2026-06-30 id: RUSTSEC-2024-0384 reason: transitive via backoff in polymarket-client-sdk.
+  # expires: 2026-07-31 id: RUSTSEC-2024-0384 reason: transitive via backoff in polymarket-client-sdk.
   "RUSTSEC-2024-0384",
-  # expires: 2026-06-30 id: RUSTSEC-2024-0436 reason: proc-macro dependency via alloy stack; runtime impact is low.
+  # expires: 2026-07-31 id: RUSTSEC-2024-0436 reason: proc-macro dependency via alloy stack; runtime impact is low.
   "RUSTSEC-2024-0436",
-  # expires: 2026-06-30 id: RUSTSEC-2026-0173 reason: proc-macro dependency via alloy stack; runtime impact is low.
+  # expires: 2026-07-31 id: RUSTSEC-2026-0173 reason: proc-macro dependency via alloy stack; runtime impact is low.
   "RUSTSEC-2026-0173",
-  # expires: 2026-06-30 id: RUSTSEC-2024-0388 reason: lockfile-only advisory in current build graph; no reachable path from active target/features.
+  # expires: 2026-07-31 id: RUSTSEC-2024-0388 reason: lockfile-only advisory in current build graph; no reachable path from active target/features.
   "RUSTSEC-2024-0388",
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EVPoly Changelog
 
+## v2.5.2 - 2026-07-01
+- Added a final Endgame Polymarket price-band guard before fast FAK submit, reducing size on stale/unavailable final quotes and skipping fresh out-of-band markets.
+- Changed Endgame overlap handling so only the longest enabled timeframe trades when multiple enabled timeframes for the same symbol close together.
+
 ## v2.5.1 - 2026-06-30
 - Enforced Endgame share-unit sizing so FAK/FOK BUY submissions use configured shares directly without falling back through USD notional conversion.
 - Restored Endgame V1 to the three legacy submit ticks while keeping symbol-specific near-base thresholds.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,7 +3344,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polymarket-arbitrage-bot"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-arbitrage-bot"
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 license-file = "LICENSE"
 default-run = "polymarket-arbitrage-bot"

--- a/src/api.rs
+++ b/src/api.rs
@@ -2847,6 +2847,24 @@ impl PolymarketApi {
         self.ws_state.lock().await.clone()
     }
 
+    pub async fn get_endgame_quote_cache_snapshot(
+        &self,
+        token_id: &str,
+        max_age_ms: i64,
+    ) -> Option<crate::endgame_quote_cache::EndgameQuoteSnapshot> {
+        if !self.ws_enabled {
+            return None;
+        }
+        let ws_state = self.ws_state_snapshot().await?;
+        let cache = ws_state.endgame_quote_cache()?;
+        let now_ms = Utc::now().timestamp_millis();
+        let snapshot = cache.latest(token_id)?;
+        if !snapshot.valid || snapshot.age_ms(now_ms) > max_age_ms {
+            return None;
+        }
+        Some(snapshot)
+    }
+
     /// Get all active markets (using events keyset endpoint)
     pub async fn get_all_active_markets(&self, limit: u32) -> Result<Vec<Market>> {
         self.get_all_active_markets_page(limit, 0).await

--- a/src/endgame_sweep.rs
+++ b/src/endgame_sweep.rs
@@ -937,6 +937,14 @@ fn normal_cdf(x: f64) -> f64 {
     (0.5 * (1.0 + erf)).clamp(0.0, 1.0)
 }
 
+pub fn poly_price_band_for_tick(tick_index: u32) -> (f64, f64) {
+    match tick_index {
+        0 => (0.97, 0.99),
+        1 => (0.98, 0.99),
+        _ => (0.98, 0.99),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9250,6 +9250,7 @@ async fn main() -> Result<()> {
         let endgame_symbols_for_loop = endgame_symbols.clone();
         let signal_state_for_endgame = signal_state.clone();
         let endgame_timeframes = endgame_cfg.enabled_timeframes();
+        let endgame_overlap_timeframes_for_loop = endgame_timeframes.clone();
         let mut coinbase_states_by_symbol: std::collections::HashMap<
             String,
             coinbase_ws::SharedCoinbaseBookState,
@@ -9560,18 +9561,6 @@ async fn main() -> Result<()> {
                 for symbol in endgame_symbols_for_loop.iter() {
                     let symbol_market_key = symbol.to_ascii_lowercase();
                     for timeframe in endgame_cfg_for_loop.enabled_timeframes() {
-                        let Some(coinbase_snapshot) = read_endgame_proxy_book_snapshot(
-                            symbol.as_str(),
-                            timeframe,
-                            now_ms,
-                            endgame_cfg_for_loop.book_freshness_ms,
-                            coinbase_states_for_endgame.as_ref(),
-                            endgame_binance_states_for_loop.as_ref(),
-                        )
-                        .await
-                        else {
-                            continue;
-                        };
                         let market_open_ts = endgame_sweep::timeframe_open_ts(now_ts, timeframe);
                         if market_open_ts <= 0 {
                             continue;
@@ -9581,54 +9570,9 @@ async fn main() -> Result<()> {
                         if now_ts < market_open_ts || now_ts >= market_close_ts {
                             continue;
                         }
-                        if let Some(mid_cb) = coinbase_snapshot
-                            .mid_price
-                            .filter(|v| v.is_finite() && *v > 0.0)
-                        {
-                            base_mid_by_period
-                                .entry((symbol_market_key.clone(), timeframe, market_open_ts))
-                                .or_insert(mid_cb);
-                        }
-                        let Some(base_mid_cb) = base_mid_by_period
-                            .get(&(symbol_market_key.clone(), timeframe, market_open_ts))
-                            .copied()
-                        else {
-                            continue;
-                        };
                         let market_close_ms = market_close_ts.saturating_mul(1_000);
                         let market_open_ms = market_open_ts.saturating_mul(1_000);
                         let period_key = (symbol_market_key.clone(), timeframe, market_open_ts);
-                        if endgame_v1_requires_dual_proxy(symbol.as_str()) {
-                            if let Some(coinbase_sample) =
-                                endgame_v1_spot_sample_from_book(&coinbase_snapshot)
-                            {
-                                endgame_v1_open_spot_by_period_proxy
-                                    .entry((
-                                        symbol_market_key.clone(),
-                                        timeframe,
-                                        market_open_ts,
-                                        EndgameV1ProxyKind::Coinbase,
-                                    ))
-                                    .or_insert(coinbase_sample);
-                            }
-                            if let Some(binance_sample) = read_endgame_binance_spot_sample(
-                                symbol.as_str(),
-                                now_ms,
-                                endgame_cfg_for_loop.book_freshness_ms,
-                                endgame_binance_states_for_loop.as_ref(),
-                            )
-                            .await
-                            {
-                                endgame_v1_open_spot_by_period_proxy
-                                    .entry((
-                                        symbol_market_key.clone(),
-                                        timeframe,
-                                        market_open_ts,
-                                        EndgameV1ProxyKind::Binance,
-                                    ))
-                                    .or_insert(binance_sample);
-                            }
-                        }
                         if !endgame_alpha_policy_by_period.contains_key(&period_key) {
                             let policy = local_endgame_alpha_policy(endgame_cfg_for_loop.as_ref());
                             log_event(
@@ -9694,6 +9638,93 @@ async fn main() -> Result<()> {
                         let Some(due_tick_index) = due_tick_index else {
                             continue;
                         };
+                        if let Some(preferred_timeframe) =
+                            endgame_preferred_overlap_timeframe_for_close(
+                                endgame_overlap_timeframes_for_loop.as_slice(),
+                                market_close_ts,
+                            )
+                        {
+                            if preferred_timeframe != timeframe {
+                                log_event(
+                                    "endgame_skip_overlap_lower_timeframe",
+                                    json!({
+                                        "strategy_id": STRATEGY_ID_ENDGAME_SWEEP_V1,
+                                        "asset_symbol": symbol,
+                                        "market_key": symbol_market_key.as_str(),
+                                        "timeframe": timeframe.as_str(),
+                                        "preferred_timeframe": preferred_timeframe.as_str(),
+                                        "market_open_ts": market_open_ts,
+                                        "market_close_ts": market_close_ts,
+                                        "tick_index": due_tick_index,
+                                        "reason": "longer_timeframe_closes_same_window"
+                                    }),
+                                );
+                                processed_tick_slots.insert((
+                                    symbol_market_key.clone(),
+                                    timeframe,
+                                    market_open_ts,
+                                    due_tick_index,
+                                ));
+                                continue;
+                            }
+                        }
+                        let Some(coinbase_snapshot) = read_endgame_proxy_book_snapshot(
+                            symbol.as_str(),
+                            timeframe,
+                            now_ms,
+                            endgame_cfg_for_loop.book_freshness_ms,
+                            coinbase_states_for_endgame.as_ref(),
+                            endgame_binance_states_for_loop.as_ref(),
+                        )
+                        .await
+                        else {
+                            continue;
+                        };
+                        if let Some(mid_cb) = coinbase_snapshot
+                            .mid_price
+                            .filter(|v| v.is_finite() && *v > 0.0)
+                        {
+                            base_mid_by_period
+                                .entry((symbol_market_key.clone(), timeframe, market_open_ts))
+                                .or_insert(mid_cb);
+                        }
+                        let Some(base_mid_cb) = base_mid_by_period
+                            .get(&(symbol_market_key.clone(), timeframe, market_open_ts))
+                            .copied()
+                        else {
+                            continue;
+                        };
+                        if endgame_v1_requires_dual_proxy(symbol.as_str()) {
+                            if let Some(coinbase_sample) =
+                                endgame_v1_spot_sample_from_book(&coinbase_snapshot)
+                            {
+                                endgame_v1_open_spot_by_period_proxy
+                                    .entry((
+                                        symbol_market_key.clone(),
+                                        timeframe,
+                                        market_open_ts,
+                                        EndgameV1ProxyKind::Coinbase,
+                                    ))
+                                    .or_insert(coinbase_sample);
+                            }
+                            if let Some(binance_sample) = read_endgame_binance_spot_sample(
+                                symbol.as_str(),
+                                now_ms,
+                                endgame_cfg_for_loop.book_freshness_ms,
+                                endgame_binance_states_for_loop.as_ref(),
+                            )
+                            .await
+                            {
+                                endgame_v1_open_spot_by_period_proxy
+                                    .entry((
+                                        symbol_market_key.clone(),
+                                        timeframe,
+                                        market_open_ts,
+                                        EndgameV1ProxyKind::Binance,
+                                    ))
+                                    .or_insert(binance_sample);
+                            }
+                        }
 
                         if endgame_v1_requires_dual_proxy(symbol.as_str()) {
                             let coinbase_open = endgame_v1_open_spot_by_period_proxy
@@ -26776,6 +26807,25 @@ fn local_endgame_alpha_policy(cfg: &EndgameExecutionConfig) -> EndgameAlphaPolic
     }
 }
 
+fn endgame_timeframe_closes_at(timeframe: Timeframe, market_close_ts: i64) -> bool {
+    if market_close_ts <= 0 {
+        return false;
+    }
+    let open_ts = endgame_sweep::timeframe_open_ts(market_close_ts.saturating_sub(1), timeframe);
+    open_ts.saturating_add(timeframe.duration_seconds()) == market_close_ts
+}
+
+fn endgame_preferred_overlap_timeframe_for_close(
+    enabled_timeframes: &[Timeframe],
+    market_close_ts: i64,
+) -> Option<Timeframe> {
+    enabled_timeframes
+        .iter()
+        .copied()
+        .filter(|timeframe| endgame_timeframe_closes_at(*timeframe, market_close_ts))
+        .max_by_key(|timeframe| timeframe.duration_seconds())
+}
+
 fn env_i64_clamped(name: &str, default: i64, min: i64, max: i64) -> i64 {
     env_i64_named(name, default).clamp(min, max)
 }
@@ -29612,6 +29662,44 @@ mod tests {
         assert_eq!(endgame_sweep::poly_price_band_for_tick(1), (0.98, 0.99));
         assert_eq!(endgame_sweep::poly_price_band_for_tick(2), (0.98, 0.99));
         assert_eq!(endgame_sweep::poly_price_band_for_tick(7), (0.98, 0.99));
+    }
+
+    #[test]
+    fn endgame_overlap_prefers_longest_enabled_timeframe() {
+        let enabled = [Timeframe::M5, Timeframe::M15, Timeframe::H1, Timeframe::H4];
+
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 15 * 60),
+            Some(Timeframe::M15)
+        );
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 60 * 60),
+            Some(Timeframe::H1)
+        );
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 4 * 60 * 60),
+            Some(Timeframe::H4)
+        );
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 5 * 60),
+            Some(Timeframe::M5)
+        );
+    }
+
+    #[test]
+    fn endgame_overlap_falls_back_when_higher_timeframe_disabled() {
+        let enabled = [Timeframe::M5, Timeframe::M15, Timeframe::H1];
+
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 4 * 60 * 60),
+            Some(Timeframe::H1)
+        );
+
+        let enabled = [Timeframe::M5, Timeframe::M15];
+        assert_eq!(
+            endgame_preferred_overlap_timeframe_for_close(&enabled, 60 * 60),
+            Some(Timeframe::M15)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,10 +287,11 @@ enum EvsnipeSubmitOutcome {
     Failed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum EndgameSubmitOutcome {
-    Submitted,
+    Submitted(f64),
     Unknown,
+    Skipped,
     Failed,
 }
 
@@ -8316,8 +8317,9 @@ async fn main() -> Result<()> {
                             }
                         }
 
+                        let mut endgame_submitted_notional_usd: Option<f64> = None;
                         let submit_result = if endgame_fast_submit_enabled {
-                            trader_for_submit
+                            match trader_for_submit
                                 .execute_endgame_buy_fast(
                                     &request.opportunity,
                                     request.endgame_intent.as_ref().expect("checked is_some"),
@@ -8325,6 +8327,13 @@ async fn main() -> Result<()> {
                                     Some(request.request_id.as_str()),
                                 )
                                 .await
+                            {
+                                Ok(submitted_notional_usd) => {
+                                    endgame_submitted_notional_usd = Some(submitted_notional_usd);
+                                    Ok(())
+                                }
+                                Err(error) => Err(error),
+                            }
                         } else if request.intent.strategy_id == STRATEGY_ID_EVSNIPE_V1
                             && matches!(request.entry_mode, EntryExecutionMode::Evsnipe)
                             && request.evsnipe_intent.is_some()
@@ -8355,6 +8364,46 @@ async fn main() -> Result<()> {
                             let err_text = e.to_string();
                             let err_kind = classify_submit_error_kind(err_text.as_str());
                             let class = classify_entry_error(err_text.as_str());
+                            let endgame_final_band_skip =
+                                matches!(request.entry_mode, EntryExecutionMode::Endgame) && {
+                                    let lower = err_text.to_ascii_lowercase();
+                                    lower.contains("endgame_submit_poly_price_band_guard")
+                                        || lower.contains("endgame_final_size_below_min_order")
+                                };
+                            if endgame_final_band_skip {
+                                let mut gate = worker_idempotency_for_submit.lock().await;
+                                gate.finish_without_cooldown(
+                                    &logical_key_for_submit,
+                                    &scope_key_for_submit,
+                                );
+                                drop(gate);
+                                endgame_submit_outcome_guard.send(EndgameSubmitOutcome::Skipped);
+                                log_event(
+                                    "endgame_submit_expected_skipped",
+                                    json!({
+                                        "request_id": request.request_id,
+                                        "logical_key": logical_key_for_submit.as_compact_string(),
+                                        "strategy_id": request.intent.strategy_id,
+                                        "timeframe": scope_key_for_submit.timeframe,
+                                        "entry_mode": request.entry_mode.as_str(),
+                                        "rung_id": rung_id_for_submit,
+                                        "period_timestamp": request.opportunity.period_timestamp,
+                                        "token_id": request.opportunity.token_id,
+                                        "error": err_text.as_str(),
+                                        "worker_pool": pool_label_for_submit
+                                    }),
+                                );
+                                request.timing.worker_done_ts_ms =
+                                    Some(chrono::Utc::now().timestamp_millis());
+                                log_arbiter_request_timing(
+                                    &request,
+                                    pool_label_for_submit,
+                                    worker_index,
+                                    "reject_endgame_expected_skip",
+                                    Some(err_text.as_str()),
+                                );
+                                return;
+                            }
                             let evsnipe_no_fill = request.intent.strategy_id
                                 == STRATEGY_ID_EVSNIPE_V1
                                 && matches!(request.entry_mode, EntryExecutionMode::Evsnipe)
@@ -8515,7 +8564,10 @@ async fn main() -> Result<()> {
                             );
                             return;
                         }
-                        endgame_submit_outcome_guard.send(EndgameSubmitOutcome::Submitted);
+                        endgame_submit_outcome_guard.send(EndgameSubmitOutcome::Submitted(
+                            endgame_submitted_notional_usd
+                                .unwrap_or(request.intent.target_size_usd),
+                        ));
                         evsnipe_submit_outcome_guard.send(EvsnipeSubmitOutcome::Submitted);
 
                         let mut gate = worker_idempotency_for_submit.lock().await;
@@ -9430,30 +9482,54 @@ async fn main() -> Result<()> {
                 let now_ts = now_ms.saturating_div(1_000);
                 while let Ok(event) = endgame_submit_outcome_rx.try_recv() {
                     let submit_status = match event.outcome {
-                        EndgameSubmitOutcome::Submitted => "submitted",
+                        EndgameSubmitOutcome::Submitted(_) => "submitted",
                         EndgameSubmitOutcome::Unknown => "submit_unknown",
+                        EndgameSubmitOutcome::Skipped => "submit_skipped",
                         EndgameSubmitOutcome::Failed => "submit_failed",
                     };
-                    if matches!(
-                        event.outcome,
-                        EndgameSubmitOutcome::Submitted | EndgameSubmitOutcome::Unknown
-                    ) {
-                        emitted_ticks.insert(event.emit_key);
-                        processed_tick_slots.insert((
-                            event.symbol_market_key.clone(),
-                            event.timeframe,
-                            event.market_open_ts,
-                            event.tick_index,
-                        ));
-                        period_direction_locks
-                            .insert(event.period_budget_key.clone(), event.direction);
-                        submitted_notional_by_period
-                            .entry(event.period_budget_key)
-                            .and_modify(|v| *v += event.effective_size_usd)
-                            .or_insert(event.effective_size_usd);
-                    } else {
-                        forget_enqueue_dedupe_key(&enqueue_dedupe_for_endgame, &event.logical_key)
+                    let accounted_effective_size_usd = match event.outcome {
+                        EndgameSubmitOutcome::Submitted(submitted_notional_usd) => {
+                            submitted_notional_usd
+                        }
+                        _ => event.effective_size_usd,
+                    };
+                    match event.outcome {
+                        EndgameSubmitOutcome::Submitted(_) | EndgameSubmitOutcome::Unknown => {
+                            emitted_ticks.insert(event.emit_key);
+                            processed_tick_slots.insert((
+                                event.symbol_market_key.clone(),
+                                event.timeframe,
+                                event.market_open_ts,
+                                event.tick_index,
+                            ));
+                            period_direction_locks
+                                .insert(event.period_budget_key.clone(), event.direction);
+                            submitted_notional_by_period
+                                .entry(event.period_budget_key)
+                                .and_modify(|v| *v += accounted_effective_size_usd)
+                                .or_insert(accounted_effective_size_usd);
+                        }
+                        EndgameSubmitOutcome::Skipped => {
+                            emitted_ticks.insert(event.emit_key);
+                            processed_tick_slots.insert((
+                                event.symbol_market_key.clone(),
+                                event.timeframe,
+                                event.market_open_ts,
+                                event.tick_index,
+                            ));
+                            forget_enqueue_dedupe_key(
+                                &enqueue_dedupe_for_endgame,
+                                &event.logical_key,
+                            )
                             .await;
+                        }
+                        EndgameSubmitOutcome::Failed => {
+                            forget_enqueue_dedupe_key(
+                                &enqueue_dedupe_for_endgame,
+                                &event.logical_key,
+                            )
+                            .await;
+                        }
                     }
                     log_event(
                         "endgame_alpha_tick_executed",
@@ -9466,6 +9542,8 @@ async fn main() -> Result<()> {
                             "tick_index": event.tick_index,
                             "request_id": event.request_id.as_str(),
                             "status": submit_status,
+                            "requested_effective_size_usd": event.effective_size_usd,
+                            "accounted_effective_size_usd": accounted_effective_size_usd,
                             "submit_outcome_wait_ms": event.outcome_wait_ms,
                             "alpha_tick_offsets_ms": event.alpha_tick_offsets_ms,
                             "alpha_submit_proxy_max_age_ms": event.alpha_submit_proxy_max_age_ms,
@@ -9910,7 +9988,7 @@ async fn main() -> Result<()> {
                         let mut side_eval_count = 0usize;
                         let sweep_fixed_limit_price = 0.99_f64;
                         let (sweep_poly_price_min, sweep_poly_price_max) =
-                            endgame_sweep_poly_price_band_for_tick(plan.tick_index);
+                            endgame_sweep::poly_price_band_for_tick(plan.tick_index);
                         let sweep_fair_poly_gap_max: Option<f64> = None;
                         for direction in [Direction::Up, Direction::Down] {
                             if direction != favored_direction {
@@ -10628,6 +10706,7 @@ async fn main() -> Result<()> {
                             tick_size: min_tick_size,
                             units: sizing.shares,
                             notional_usd: effective_size_usd,
+                            min_order_size_usd,
                             fair_probability: pricing.fair_probability,
                             execution_probability: pricing.execution_probability,
                             edge_bps_at_vwap: sizing.edge_bps_at_vwap,
@@ -25624,35 +25703,6 @@ fn cap_endgame_sizing_to_period_remaining_usd(
     effective_size_usd
 }
 
-fn endgame_sweep_poly_price_band_for_tick(tick_index: u32) -> (f64, f64) {
-    if let Ok(raw) = std::env::var("EVPOLY_ENDGAME_SWEEP_POLY_PRICE_BAND") {
-        if let Some(parsed) = parse_price_band(raw.as_str()) {
-            return parsed;
-        }
-    }
-    let tick_key = format!("EVPOLY_ENDGAME_SWEEP_POLY_PRICE_BAND_TICK{}", tick_index);
-    if let Ok(raw) = std::env::var(tick_key.as_str()) {
-        if let Some(parsed) = parse_price_band(raw.as_str()) {
-            return parsed;
-        }
-    }
-    match tick_index {
-        0 => (0.95, 0.99),
-        1 => (0.97, 0.99),
-        _ => (0.98, 0.99),
-    }
-}
-
-fn parse_price_band(raw: &str) -> Option<(f64, f64)> {
-    let (min_raw, max_raw) = raw.split_once('-')?;
-    let min_v = min_raw.trim().parse::<f64>().ok()?;
-    let max_v = max_raw.trim().parse::<f64>().ok()?;
-    if !min_v.is_finite() || !max_v.is_finite() || min_v <= 0.0 || max_v < min_v {
-        return None;
-    }
-    Some((min_v.clamp(0.01, 0.99), max_v.clamp(0.01, 0.99)))
-}
-
 fn to_json_string(value: Value) -> Option<String> {
     serde_json::to_string(&value).ok()
 }
@@ -29558,10 +29608,10 @@ mod tests {
 
     #[test]
     fn endgame_sweep_price_band_varies_by_tick() {
-        assert_eq!(endgame_sweep_poly_price_band_for_tick(0), (0.95, 0.99));
-        assert_eq!(endgame_sweep_poly_price_band_for_tick(1), (0.97, 0.99));
-        assert_eq!(endgame_sweep_poly_price_band_for_tick(2), (0.98, 0.99));
-        assert_eq!(endgame_sweep_poly_price_band_for_tick(7), (0.98, 0.99));
+        assert_eq!(endgame_sweep::poly_price_band_for_tick(0), (0.97, 0.99));
+        assert_eq!(endgame_sweep::poly_price_band_for_tick(1), (0.98, 0.99));
+        assert_eq!(endgame_sweep::poly_price_band_for_tick(2), (0.98, 0.99));
+        assert_eq!(endgame_sweep::poly_price_band_for_tick(7), (0.98, 0.99));
     }
 
     #[test]

--- a/src/trader.rs
+++ b/src/trader.rs
@@ -47,6 +47,41 @@ pub const STRATEGY_ID_MANUAL_PREMARKET_TAKER_V1: &str = "manual_premarket_taker_
 pub const STRATEGY_ID_MANUAL_CHASE_LIMIT_V1: &str = "manual_chase_limit_v1";
 pub const STRATEGY_ID_MANUAL_CHASE_LIMIT_TAKER_V1: &str = "manual_chase_limit_taker_v1";
 const ENDGAME_FAST_SUBMIT_DEADLINE_GUARD_MS: i64 = 25;
+const ENDGAME_FINAL_PM_QUOTE_MAX_AGE_MS: i64 = 200;
+const ENDGAME_FINAL_PM_REST_TIMEOUT_MS: u64 = 200;
+const ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER: f64 = 0.5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndgameFinalPmQuoteAction {
+    SubmitFull,
+    SubmitReduced,
+    Skip,
+}
+
+impl EndgameFinalPmQuoteAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SubmitFull => "submit_full",
+            Self::SubmitReduced => "submit_reduced",
+            Self::Skip => "skip",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EndgameFinalPmQuoteDecision {
+    action: EndgameFinalPmQuoteAction,
+    reason: &'static str,
+    size_multiplier: f64,
+    source: &'static str,
+    best_bid: Option<f64>,
+    best_ask: Option<f64>,
+    poly_mid: Option<f64>,
+    quote_ts_ms: Option<i64>,
+    quote_age_ms: Option<i64>,
+    band_min: f64,
+    band_max: f64,
+}
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EvsnipeOrderIntent {
@@ -90,6 +125,7 @@ pub struct EndgameOrderIntent {
     pub tick_size: f64,
     pub units: f64,
     pub notional_usd: f64,
+    pub min_order_size_usd: f64,
     pub fair_probability: f64,
     pub execution_probability: f64,
     pub edge_bps_at_vwap: f64,
@@ -5859,13 +5895,208 @@ impl Trader {
             })
     }
 
+    fn endgame_final_pm_poly_mid(best_bid: Option<f64>, best_ask: Option<f64>) -> Option<f64> {
+        let best_bid = best_bid.filter(|value| value.is_finite() && *value > 0.0)?;
+        let best_ask = best_ask.filter(|value| value.is_finite() && *value > 0.0)?;
+        if best_ask < best_bid {
+            return None;
+        }
+        Some((best_bid + best_ask) / 2.0)
+    }
+
+    fn endgame_final_pm_quote_decision_from_parts(
+        source: &'static str,
+        best_bid: Option<f64>,
+        best_ask: Option<f64>,
+        quote_ts_ms: Option<i64>,
+        now_ms: i64,
+        tick_index: u32,
+    ) -> EndgameFinalPmQuoteDecision {
+        let (band_min, band_max) = crate::endgame_sweep::poly_price_band_for_tick(tick_index);
+        let quote_age_ms = quote_ts_ms
+            .filter(|ts| *ts > 0)
+            .map(|ts| now_ms.saturating_sub(ts).max(0));
+        let poly_mid = Self::endgame_final_pm_poly_mid(best_bid, best_ask);
+
+        if quote_age_ms
+            .map(|age| age > ENDGAME_FINAL_PM_QUOTE_MAX_AGE_MS)
+            .unwrap_or(true)
+        {
+            return EndgameFinalPmQuoteDecision {
+                action: EndgameFinalPmQuoteAction::SubmitReduced,
+                reason: "quote_missing_or_stale",
+                size_multiplier: ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER,
+                source,
+                best_bid,
+                best_ask,
+                poly_mid,
+                quote_ts_ms,
+                quote_age_ms,
+                band_min,
+                band_max,
+            };
+        }
+
+        let Some(poly_mid) = poly_mid else {
+            return EndgameFinalPmQuoteDecision {
+                action: EndgameFinalPmQuoteAction::SubmitReduced,
+                reason: "poly_mid_unavailable",
+                size_multiplier: ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER,
+                source,
+                best_bid,
+                best_ask,
+                poly_mid: None,
+                quote_ts_ms,
+                quote_age_ms,
+                band_min,
+                band_max,
+            };
+        };
+
+        if poly_mid < band_min || poly_mid > band_max {
+            return EndgameFinalPmQuoteDecision {
+                action: EndgameFinalPmQuoteAction::Skip,
+                reason: "poly_mid_outside_entry_band",
+                size_multiplier: 0.0,
+                source,
+                best_bid,
+                best_ask,
+                poly_mid: Some(poly_mid),
+                quote_ts_ms,
+                quote_age_ms,
+                band_min,
+                band_max,
+            };
+        }
+
+        EndgameFinalPmQuoteDecision {
+            action: EndgameFinalPmQuoteAction::SubmitFull,
+            reason: "poly_mid_inside_entry_band",
+            size_multiplier: 1.0,
+            source,
+            best_bid,
+            best_ask,
+            poly_mid: Some(poly_mid),
+            quote_ts_ms,
+            quote_age_ms,
+            band_min,
+            band_max,
+        }
+    }
+
+    fn best_bid_ask_from_orderbook_f64(orderbook: &OrderBook) -> (Option<f64>, Option<f64>) {
+        let best_bid = orderbook
+            .bids
+            .iter()
+            .filter_map(|level| {
+                let price = f64::try_from(level.price).ok()?;
+                let size = f64::try_from(level.size).ok()?;
+                (price.is_finite() && price > 0.0 && size.is_finite() && size > 0.0)
+                    .then_some(price)
+            })
+            .max_by(|left, right| left.total_cmp(right));
+        let best_ask = orderbook
+            .asks
+            .iter()
+            .filter_map(|level| {
+                let price = f64::try_from(level.price).ok()?;
+                let size = f64::try_from(level.size).ok()?;
+                (price.is_finite() && price > 0.0 && size.is_finite() && size > 0.0)
+                    .then_some(price)
+            })
+            .min_by(|left, right| left.total_cmp(right));
+        (best_bid, best_ask)
+    }
+
+    async fn endgame_final_pm_quote_decision(
+        &self,
+        intent: &EndgameOrderIntent,
+        now_ms: i64,
+    ) -> EndgameFinalPmQuoteDecision {
+        if intent.tick_index <= 1 {
+            let result = tokio::time::timeout(
+                tokio::time::Duration::from_millis(ENDGAME_FINAL_PM_REST_TIMEOUT_MS),
+                self.api
+                    .get_orderbook_rest_snapshot(intent.token_id.as_str()),
+            )
+            .await;
+            return match result {
+                Ok(Ok(snapshot)) => {
+                    let (best_bid, best_ask) =
+                        Self::best_bid_ask_from_orderbook_f64(&snapshot.orderbook);
+                    Self::endgame_final_pm_quote_decision_from_parts(
+                        "polymarket_rest_book",
+                        best_bid,
+                        best_ask,
+                        snapshot.source_ts_ms,
+                        chrono::Utc::now().timestamp_millis(),
+                        intent.tick_index,
+                    )
+                }
+                Ok(Err(_)) => EndgameFinalPmQuoteDecision {
+                    action: EndgameFinalPmQuoteAction::SubmitReduced,
+                    reason: "rest_quote_unavailable",
+                    size_multiplier: ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER,
+                    source: "polymarket_rest_book",
+                    best_bid: None,
+                    best_ask: None,
+                    poly_mid: None,
+                    quote_ts_ms: None,
+                    quote_age_ms: None,
+                    band_min: crate::endgame_sweep::poly_price_band_for_tick(intent.tick_index).0,
+                    band_max: crate::endgame_sweep::poly_price_band_for_tick(intent.tick_index).1,
+                },
+                Err(_) => EndgameFinalPmQuoteDecision {
+                    action: EndgameFinalPmQuoteAction::SubmitReduced,
+                    reason: "rest_quote_timeout",
+                    size_multiplier: ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER,
+                    source: "polymarket_rest_book",
+                    best_bid: None,
+                    best_ask: None,
+                    poly_mid: None,
+                    quote_ts_ms: None,
+                    quote_age_ms: None,
+                    band_min: crate::endgame_sweep::poly_price_band_for_tick(intent.tick_index).0,
+                    band_max: crate::endgame_sweep::poly_price_band_for_tick(intent.tick_index).1,
+                },
+            };
+        }
+
+        if let Some(snapshot) = self
+            .api
+            .get_endgame_quote_cache_snapshot(
+                intent.token_id.as_str(),
+                ENDGAME_FINAL_PM_QUOTE_MAX_AGE_MS,
+            )
+            .await
+        {
+            return Self::endgame_final_pm_quote_decision_from_parts(
+                snapshot.source.as_str(),
+                snapshot.best_bid,
+                snapshot.best_ask,
+                Some(snapshot.updated_ms),
+                chrono::Utc::now().timestamp_millis(),
+                intent.tick_index,
+            );
+        }
+
+        Self::endgame_final_pm_quote_decision_from_parts(
+            "endgame_quote_cache",
+            None,
+            None,
+            None,
+            now_ms,
+            intent.tick_index,
+        )
+    }
+
     pub async fn execute_endgame_buy_fast(
         &self,
         opportunity: &BuyOpportunity,
         intent: &EndgameOrderIntent,
         source_timeframe: Option<&str>,
         request_id: Option<&str>,
-    ) -> Result<()> {
+    ) -> Result<f64> {
         let strategy_id = if intent.strategy_id.trim().is_empty() {
             crate::strategy::STRATEGY_ID_ENDGAME_SWEEP_V1
         } else {
@@ -6108,12 +6339,116 @@ impl Trader {
             return Err(anyhow!(reason));
         }
 
-        let units = intent.units;
+        let final_pm_quote_decision = self.endgame_final_pm_quote_decision(intent, now_ms).await;
+        log_event(
+            "endgame_submit_poly_price_band_guard",
+            json!({
+                "strategy_id": strategy_id,
+                "request_id": request_id.as_deref(),
+                "symbol": intent.symbol.as_str(),
+                "timeframe": intent.timeframe.as_str(),
+                "condition_id": intent.condition_id.as_str(),
+                "token_id": intent.token_id.as_str(),
+                "direction": intent.direction.as_str(),
+                "market_open_ts": intent.market_open_ts,
+                "market_close_ts": intent.market_close_ts,
+                "tick_index": intent.tick_index,
+                "source": final_pm_quote_decision.source,
+                "action": final_pm_quote_decision.action.as_str(),
+                "reason": final_pm_quote_decision.reason,
+                "best_bid": final_pm_quote_decision.best_bid,
+                "best_ask": final_pm_quote_decision.best_ask,
+                "poly_mid": final_pm_quote_decision.poly_mid,
+                "quote_ts_ms": final_pm_quote_decision.quote_ts_ms,
+                "quote_age_ms": final_pm_quote_decision.quote_age_ms,
+                "quote_max_age_ms": ENDGAME_FINAL_PM_QUOTE_MAX_AGE_MS,
+                "poly_price_min": final_pm_quote_decision.band_min,
+                "poly_price_max": final_pm_quote_decision.band_max,
+                "original_units": intent.units,
+                "size_multiplier": final_pm_quote_decision.size_multiplier
+            }),
+        );
+        if final_pm_quote_decision.action == EndgameFinalPmQuoteAction::Skip {
+            let reason =
+                "endgame_submit_poly_price_band_guard: poly_mid_outside_entry_band".to_string();
+            self.record_entry_precheck_failure(
+                strategy_id,
+                source_timeframe.as_str(),
+                entry_mode,
+                opportunity,
+                Some(submit_price),
+                Some(intent.units),
+                Some(intent.units.max(0.0) * submit_price.max(0.0)),
+                reason.clone(),
+            );
+            return Err(anyhow!(reason));
+        }
+
+        let now_after_final_guard_ms = chrono::Utc::now().timestamp_millis();
+        if market_close_ms <= 0 || now_after_final_guard_ms >= latest_submit_ms {
+            let reason = format!(
+                "endgame_submit_deadline_guard_after_quote: now_ms={} market_close_ms={} guard_ms={}",
+                now_after_final_guard_ms, market_close_ms, ENDGAME_FAST_SUBMIT_DEADLINE_GUARD_MS
+            );
+            self.record_entry_precheck_failure(
+                strategy_id,
+                source_timeframe.as_str(),
+                entry_mode,
+                opportunity,
+                Some(submit_price),
+                Some(intent.units),
+                Some(intent.units.max(0.0) * submit_price.max(0.0)),
+                reason.clone(),
+            );
+            log_event(
+                "endgame_submit_deadline_guard",
+                json!({
+                    "strategy_id": strategy_id,
+                    "request_id": request_id.as_deref(),
+                    "symbol": intent.symbol.as_str(),
+                    "timeframe": intent.timeframe.as_str(),
+                    "condition_id": intent.condition_id.as_str(),
+                    "token_id": intent.token_id.as_str(),
+                    "direction": intent.direction.as_str(),
+                    "market_open_ts": intent.market_open_ts,
+                    "market_close_ts": intent.market_close_ts,
+                    "tick_index": intent.tick_index,
+                    "now_ms": now_after_final_guard_ms,
+                    "market_close_ms": market_close_ms,
+                    "latest_submit_ms": latest_submit_ms,
+                    "guard_ms": ENDGAME_FAST_SUBMIT_DEADLINE_GUARD_MS,
+                    "reason": "too_close_to_market_close_after_final_quote_guard"
+                }),
+            );
+            return Err(anyhow!(reason));
+        }
+
+        let units = intent.units * final_pm_quote_decision.size_multiplier;
         let investment_amount = units.max(0.0) * submit_price.max(0.0);
         if !units.is_finite() || units <= 0.0 || !investment_amount.is_finite() {
             let reason = format!(
                 "endgame_invalid_share_units: units={:.8} notional={:.8}",
                 units, investment_amount
+            );
+            self.record_entry_precheck_failure(
+                strategy_id,
+                source_timeframe.as_str(),
+                entry_mode,
+                opportunity,
+                Some(submit_price),
+                Some(units),
+                Some(investment_amount),
+                reason.clone(),
+            );
+            return Err(anyhow!(reason));
+        }
+        if intent.min_order_size_usd.is_finite()
+            && intent.min_order_size_usd > 0.0
+            && investment_amount + 1e-9 < intent.min_order_size_usd
+        {
+            let reason = format!(
+                "endgame_final_size_below_min_order: notional={:.8} min_order_size={:.8}",
+                investment_amount, intent.min_order_size_usd
             );
             self.record_entry_precheck_failure(
                 strategy_id,
@@ -6189,7 +6524,7 @@ impl Trader {
             };
             let mut pending = self.pending_trades.lock().await;
             pending.insert(trade_key, trade);
-            return Ok(());
+            return Ok(investment_amount);
         }
 
         let submit_timeout_ms = std::env::var("EVPOLY_ENDGAME_SUBMIT_TIMEOUT_MS")
@@ -6237,6 +6572,19 @@ impl Trader {
                     "best_bid": intent.best_bid,
                     "best_ask": intent.best_ask,
                     "poly_mid_at_intent": intent.poly_mid_at_intent,
+                    "final_pm_quote_source": final_pm_quote_decision.source,
+                    "final_pm_quote_action": final_pm_quote_decision.action.as_str(),
+                    "final_pm_quote_reason": final_pm_quote_decision.reason,
+                    "final_pm_best_bid": final_pm_quote_decision.best_bid,
+                    "final_pm_best_ask": final_pm_quote_decision.best_ask,
+                    "final_pm_poly_mid": final_pm_quote_decision.poly_mid,
+                    "final_pm_quote_ts_ms": final_pm_quote_decision.quote_ts_ms,
+                    "final_pm_quote_age_ms": final_pm_quote_decision.quote_age_ms,
+                    "final_pm_quote_max_age_ms": ENDGAME_FINAL_PM_QUOTE_MAX_AGE_MS,
+                    "final_pm_poly_price_min": final_pm_quote_decision.band_min,
+                    "final_pm_poly_price_max": final_pm_quote_decision.band_max,
+                    "final_pm_size_multiplier": final_pm_quote_decision.size_multiplier,
+                    "original_units": intent.units,
                     "tick_index": intent.tick_index,
                     "tau_seconds": intent.tau_seconds,
                     "edge_bps_at_vwap": intent.edge_bps_at_vwap,
@@ -6489,7 +6837,7 @@ impl Trader {
                         "submit_timeout_ms": submit_timeout_ms
                     }),
                 );
-                Ok(())
+                Ok(signed_investment_amount)
             }
             Err(error) => {
                 self.record_entry_precheck_failure(
@@ -16182,7 +16530,10 @@ impl Trader {
 
 #[cfg(test)]
 mod tests {
-    use super::{EntryExecutionMode, MarketOrderConstraints, Trader};
+    use super::{
+        EndgameFinalPmQuoteAction, EntryExecutionMode, MarketOrderConstraints, Trader,
+        ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER,
+    };
     use crate::detector::TokenType;
     use crate::models::{OrderResponse, PendingTrade};
     use crate::tracking_db::MmWalletInventoryRow;
@@ -16909,6 +17260,84 @@ mod tests {
         assert_eq!(Trader::tick_decimal_places(0.001), 3);
         assert_eq!(Trader::tick_decimal_places(0.0001), 4);
         assert_eq!(Trader::tick_decimal_places(1.0), 2);
+    }
+
+    #[test]
+    fn endgame_final_quote_guard_allows_fresh_in_band_quote() {
+        let decision = Trader::endgame_final_pm_quote_decision_from_parts(
+            "test",
+            Some(0.98),
+            Some(0.99),
+            Some(1_000),
+            1_150,
+            0,
+        );
+
+        assert_eq!(decision.action, EndgameFinalPmQuoteAction::SubmitFull);
+        assert_eq!(decision.reason, "poly_mid_inside_entry_band");
+        assert_eq!(decision.poly_mid, Some(0.985));
+        assert_eq!(decision.size_multiplier, 1.0);
+    }
+
+    #[test]
+    fn endgame_final_quote_guard_reduces_on_stale_or_missing_quote() {
+        let stale = Trader::endgame_final_pm_quote_decision_from_parts(
+            "test",
+            Some(0.98),
+            Some(0.99),
+            Some(1_000),
+            1_201,
+            0,
+        );
+        assert_eq!(stale.action, EndgameFinalPmQuoteAction::SubmitReduced);
+        assert_eq!(stale.reason, "quote_missing_or_stale");
+        assert_eq!(
+            stale.size_multiplier,
+            ENDGAME_FINAL_PM_STALE_SIZE_MULTIPLIER
+        );
+
+        let missing_timestamp = Trader::endgame_final_pm_quote_decision_from_parts(
+            "test",
+            Some(0.98),
+            Some(0.99),
+            None,
+            1_150,
+            0,
+        );
+        assert_eq!(
+            missing_timestamp.action,
+            EndgameFinalPmQuoteAction::SubmitReduced
+        );
+        assert_eq!(missing_timestamp.reason, "quote_missing_or_stale");
+
+        let missing_mid = Trader::endgame_final_pm_quote_decision_from_parts(
+            "test",
+            Some(0.98),
+            None,
+            Some(1_100),
+            1_150,
+            0,
+        );
+        assert_eq!(missing_mid.action, EndgameFinalPmQuoteAction::SubmitReduced);
+        assert_eq!(missing_mid.reason, "poly_mid_unavailable");
+    }
+
+    #[test]
+    fn endgame_final_quote_guard_skips_fresh_out_of_band_quote() {
+        let decision = Trader::endgame_final_pm_quote_decision_from_parts(
+            "test",
+            Some(0.95),
+            Some(0.96),
+            Some(1_000),
+            1_050,
+            0,
+        );
+
+        assert_eq!(decision.action, EndgameFinalPmQuoteAction::Skip);
+        assert_eq!(decision.reason, "poly_mid_outside_entry_band");
+        assert_eq!(decision.poly_mid, Some(0.955));
+        assert_eq!(decision.band_min, 0.97);
+        assert_eq!(decision.band_max, 0.99);
     }
 
     #[test]


### PR DESCRIPTION
Release runtime v2.5.2.\n\nIncludes:\n- Final Endgame Polymarket price-band guard before fast FAK submit.\n- Endgame longest-enabled-timeframe overlap filter.\n- Runtime version/changelog bump.\n- Security audit exception expiry refresh through 2026-07-31.