### PR TITLE
Release desktop v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EVPoly Desktop Changelog
 
+## UI-v2.5.2 - 2026-07-01
+- Bumped desktop app/updater version to 2.5.2.
+- Repinned the bundled runtime sidecar to runtime `v2.5.2` (`cdcd646`) with the final Endgame Polymarket price-band guard and longest-enabled-timeframe overlap handling.
+
 ## UI-v2.5.1 - 2026-06-30
 - Bumped desktop app/updater version to 2.5.1.
 - Repinned the bundled runtime sidecar to runtime `v2.5.1` (`3eb4fac`) with enforced Endgame share-unit sizing and the legacy t0/t1/t2 Endgame schedule.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poly-desktop",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "poly-desktop",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poly-desktop",
   "private": true,
-  "version": "2.5.1",
+  "version": "2.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "evpoly-desktop"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evpoly-desktop"
-version = "2.5.1"
+version = "2.5.2"
 description = "EVPoly Desktop - Cross-platform trading bot manager"
 authors = ["Degenapetrader"]
 license = "SEE LICENSE"

--- a/src-tauri/sidecar-core.lock
+++ b/src-tauri/sidecar-core.lock
@@ -1,2 +1,2 @@
-CORE_REF=3eb4facb196018d72d83ad4e8e22e1984ed0071b
+CORE_REF=cdcd6462211185da457cffb5bdcc49a432b70656
 CORE_REPO=https://github.com/Degenapetrader/EVPOLY.git

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EVPoly",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "identifier": "com.evpoly.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release desktop v2.5.2.

Includes:
- Desktop app/updater version bump to 2.5.2.
- Runtime sidecar lock pinned to v2.5.2 commit cdcd646.
- Changelog entry for the Endgame final PM guard and overlap filter.