### PR TITLE
Release runtime v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # EVPoly Changelog
 
+## v2.5.5 - 2026-07-02
+- Added Polymarket quarter-cent tick-size support so markets with `0.0025` ticks can build and sign valid CLOB orders.
+
 ## v2.5.4 - 2026-07-02
 - Restored Endgame V1 local anchor sampling before due-tick processing so restarts do not seed period opens from near-close samples.
 - Hard-locked Endgame runtime scope to `5m,15m` and ignored saved/env timeframe overrides.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,7 +3344,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polymarket-arbitrage-bot"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-arbitrage-bot"
-version = "2.5.4"
+version = "2.5.5"
 edition = "2021"
 license-file = "LICENSE"
 default-run = "polymarket-arbitrage-bot"

--- a/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/order_builder.rs
+++ b/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/order_builder.rs
@@ -296,6 +296,12 @@ impl<K: AuthKind> OrderBuilder<Limit, K> {
             )));
         }
 
+        if !price_aligned_to_tick_size(price, minimum_tick_size) {
+            return Err(Error::validation(format!(
+                "Price {price} is not aligned to the minimum tick size {minimum_tick_size}"
+            )));
+        }
+
         let Some(size) = self.size else {
             return Err(Error::validation(
                 "Unable to build Order due to missing size",
@@ -550,6 +556,12 @@ impl<K: AuthKind> OrderBuilder<Market, K> {
             )));
         }
 
+        if !price_aligned_to_tick_size(price, minimum_tick_size) {
+            return Err(Error::validation(format!(
+                "Price {price} is not aligned to the minimum tick size {minimum_tick_size}"
+            )));
+        }
+
         let amount = match (side, amount.0, self.user_usdc_balance) {
             (Side::Buy, AmountInner::Usdc(raw), Some(balance)) => {
                 // V2 uses `/clob-markets/{id}` `fd` (rate + exponent); `/fee-rate`
@@ -674,6 +686,10 @@ const JS_SAFE_INTEGER_MAX: u64 = (1 << 53) - 1;
 
 fn to_ieee_754_int(value: u64) -> u64 {
     value & JS_SAFE_INTEGER_MAX
+}
+
+fn price_aligned_to_tick_size(price: Decimal, tick_size: Decimal) -> bool {
+    (price % tick_size).is_zero()
 }
 
 #[must_use]

--- a/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/types/mod.rs
+++ b/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/types/mod.rs
@@ -357,6 +357,8 @@ pub enum TraderSide {
 pub enum TickSize {
     Tenth,
     Hundredth,
+    HalfCent,
+    QuarterCent,
     Thousandth,
     TenThousandth,
 }
@@ -366,6 +368,8 @@ impl fmt::Display for TickSize {
         let name = match self {
             TickSize::Tenth => "Tenth",
             TickSize::Hundredth => "Hundredth",
+            TickSize::HalfCent => "HalfCent",
+            TickSize::QuarterCent => "QuarterCent",
             TickSize::Thousandth => "Thousandth",
             TickSize::TenThousandth => "TenThousandth",
         };
@@ -380,6 +384,8 @@ impl TickSize {
         match self {
             TickSize::Tenth => dec!(0.1),
             TickSize::Hundredth => dec!(0.01),
+            TickSize::HalfCent => dec!(0.005),
+            TickSize::QuarterCent => dec!(0.0025),
             TickSize::Thousandth => dec!(0.001),
             TickSize::TenThousandth => dec!(0.0001),
         }
@@ -399,10 +405,12 @@ impl TryFrom<Decimal> for TickSize {
         match value {
             v if v == dec!(0.1) => Ok(TickSize::Tenth),
             v if v == dec!(0.01) => Ok(TickSize::Hundredth),
+            v if v == dec!(0.005) => Ok(TickSize::HalfCent),
+            v if v == dec!(0.0025) => Ok(TickSize::QuarterCent),
             v if v == dec!(0.001) => Ok(TickSize::Thousandth),
             v if v == dec!(0.0001) => Ok(TickSize::TenThousandth),
             other => Err(Error::validation(format!(
-                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.001, 0.0001"
+                "Unknown tick size: {other}. Expected one of: 0.1, 0.01, 0.005, 0.0025, 0.001, 0.0001"
             ))),
         }
     }
@@ -878,6 +886,8 @@ mod tests {
     fn tick_size_decimals_should_succeed() {
         assert_eq!(TickSize::Tenth.as_decimal().scale(), 1);
         assert_eq!(TickSize::Hundredth.as_decimal().scale(), 2);
+        assert_eq!(TickSize::HalfCent.as_decimal().scale(), 3);
+        assert_eq!(TickSize::QuarterCent.as_decimal().scale(), 4);
         assert_eq!(TickSize::Thousandth.as_decimal().scale(), 3);
         assert_eq!(TickSize::TenThousandth.as_decimal().scale(), 4);
     }
@@ -886,6 +896,8 @@ mod tests {
     fn tick_size_should_display() {
         assert_eq!(format!("{}", TickSize::Tenth), "Tenth(0.1)");
         assert_eq!(format!("{}", TickSize::Hundredth), "Hundredth(0.01)");
+        assert_eq!(format!("{}", TickSize::HalfCent), "HalfCent(0.005)");
+        assert_eq!(format!("{}", TickSize::QuarterCent), "QuarterCent(0.0025)");
         assert_eq!(format!("{}", TickSize::Thousandth), "Thousandth(0.001)");
         assert_eq!(
             format!("{}", TickSize::TenThousandth),
@@ -902,6 +914,11 @@ mod tests {
         assert_eq!(
             TickSize::try_from(dec!(0.001)).unwrap(),
             TickSize::Thousandth
+        );
+        assert_eq!(TickSize::try_from(dec!(0.005)).unwrap(), TickSize::HalfCent);
+        assert_eq!(
+            TickSize::try_from(dec!(0.0025)).unwrap(),
+            TickSize::QuarterCent
         );
         assert_eq!(TickSize::try_from(dec!(0.01)).unwrap(), TickSize::Hundredth);
         assert_eq!(TickSize::try_from(dec!(0.1)).unwrap(), TickSize::Tenth);

--- a/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/utilities.rs
+++ b/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/src/clob/utilities.rs
@@ -380,6 +380,8 @@ mod tests {
     fn price_valid_all_tick_sizes() {
         assert!(price_valid(dec!(0.5), TickSize::Tenth));
         assert!(price_valid(dec!(0.5), TickSize::Hundredth));
+        assert!(price_valid(dec!(0.5), TickSize::HalfCent));
+        assert!(price_valid(dec!(0.5), TickSize::QuarterCent));
         assert!(price_valid(dec!(0.5), TickSize::Thousandth));
         assert!(price_valid(dec!(0.5), TickSize::TenThousandth));
     }

--- a/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/tests/order.rs
+++ b/vendor-polymarket-client-sdk/polymarket_client_sdk_v2/tests/order.rs
@@ -675,6 +675,33 @@ mod limit {
     }
 
     #[tokio::test]
+    async fn should_fail_on_price_not_aligned_to_quarter_cent_tick() -> anyhow::Result<()> {
+        let server = MockServer::start();
+        let client = create_authenticated(&server).await?;
+
+        ensure_requirements(&server, token_1(), TickSize::QuarterCent);
+
+        let err = client
+            .limit_order()
+            .token_id(token_1())
+            .price(dec!(0.0526))
+            .size(dec!(21.04))
+            .side(Side::Buy)
+            .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+            .build()
+            .await
+            .unwrap_err();
+        let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+        assert_eq!(
+            msg,
+            "Price 0.0526 is not aligned to the minimum tick size 0.0025"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn should_fail_on_negative_price_and_size() -> anyhow::Result<()> {
         let server = MockServer::start();
         let client = create_authenticated(&server).await?;
@@ -785,6 +812,88 @@ mod limit {
 
             assert_eq!(signable_order.order().tokenId, token_1());
             assert_eq!(signable_order.order().makerAmount, U256::from(11_782_400));
+            assert_eq!(signable_order.order().takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Buy as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_005() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::HalfCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.055))
+                .size(dec!(21.04))
+                .side(Side::Buy)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(maker_amount) / to_decimal(taker_amount);
+            assert_eq!(price, dec!(0.055));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(1_157_200));
+            assert_eq!(signable_order.order().takerAmount, U256::from(21_040_000));
+            assert_eq!(signable_order.v2().expiration, U256::from(50000));
+
+            assert_eq!(signable_order.order().side, Side::Buy as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_0025() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements(&server, token_1(), TickSize::QuarterCent);
+
+            let signable_order = client
+                .limit_order()
+                .token_id(token_1())
+                .price(dec!(0.0525))
+                .size(dec!(21.04))
+                .side(Side::Buy)
+                .order_type(OrderType::GTD)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = to_decimal(maker_amount) / to_decimal(taker_amount);
+            assert_eq!(price, dec!(0.0525));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(1_104_600));
             assert_eq!(signable_order.order().takerAmount, U256::from(21_040_000));
             assert_eq!(signable_order.v2().expiration, U256::from(50000));
 
@@ -1347,7 +1456,22 @@ mod market {
         bids: &[OrderSummary],
         asks: &[OrderSummary],
     ) {
-        let minimum_tick_size = TickSize::Tenth;
+        ensure_requirements_for_market_price_with_tick(
+            server,
+            token_id,
+            bids,
+            asks,
+            TickSize::Tenth,
+        );
+    }
+
+    fn ensure_requirements_for_market_price_with_tick(
+        server: &MockServer,
+        token_id: U256,
+        bids: &[OrderSummary],
+        asks: &[OrderSummary],
+        minimum_tick_size: TickSize,
+    ) {
         crate::common::ensure_version(server, 2);
 
         server.mock(|when, then| {
@@ -1923,6 +2047,92 @@ mod market {
 
                 Ok(())
             }
+        }
+
+        #[tokio::test]
+        async fn should_fail_on_price_not_aligned_to_quarter_cent_tick() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements_for_market_price_with_tick(
+                &server,
+                token_1(),
+                &[],
+                &[OrderSummary::builder()
+                    .price(dec!(0.0526))
+                    .size(Decimal::ONE_HUNDRED)
+                    .build()],
+                TickSize::QuarterCent,
+            );
+
+            let err = client
+                .market_order()
+                .token_id(token_1())
+                .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
+                .side(Side::Buy)
+                .build()
+                .await
+                .unwrap_err();
+            let msg = &err.downcast_ref::<Validation>().unwrap().reason;
+
+            assert_eq!(
+                msg,
+                "Price 0.0526 is not aligned to the minimum tick size 0.0025"
+            );
+
+            Ok(())
+        }
+
+        #[tokio::test]
+        async fn should_succeed_0_0025() -> anyhow::Result<()> {
+            let server = MockServer::start();
+            let client = create_authenticated(&server).await?;
+
+            ensure_requirements_for_market_price_with_tick(
+                &server,
+                token_1(),
+                &[],
+                &[OrderSummary::builder()
+                    .price(dec!(0.0525))
+                    .size(Decimal::ONE_HUNDRED)
+                    .build()],
+                TickSize::QuarterCent,
+            );
+
+            let signable_order = client
+                .market_order()
+                .token_id(token_1())
+                .amount(Amount::usdc(Decimal::ONE_HUNDRED)?)
+                .side(Side::Buy)
+                .expiration(DateTime::<Utc>::from_str("1970-01-01T13:53:20Z").unwrap())
+                .build()
+                .await?;
+
+            let maker_amount = signable_order.order().makerAmount;
+            let taker_amount = signable_order.order().takerAmount;
+
+            let price = (to_decimal(maker_amount) / to_decimal(taker_amount))
+                .trunc_with_scale(USDC_DECIMALS);
+            assert_eq!(price, dec!(0.0525));
+
+            assert_eq!(signable_order.order().maker, client.address());
+            assert_eq!(signable_order.order().signer, client.address());
+
+            assert_eq!(signable_order.order().tokenId, token_1());
+            assert_eq!(signable_order.order().makerAmount, U256::from(100_000_000));
+            assert_eq!(
+                signable_order.order().takerAmount,
+                U256::from(1_904_761_904)
+            );
+            assert_eq!(signable_order.v2().expiration, U256::from(0));
+
+            assert_eq!(signable_order.order().side, Side::Buy as u8);
+            assert_eq!(
+                signable_order.order().signatureType,
+                SignatureType::Eoa as u8
+            );
+
+            Ok(())
         }
 
         #[tokio::test]


### PR DESCRIPTION
## Summary
- Release runtime v2.5.5
- Include quarter-cent Polymarket tick-size support for 0.0025 markets

## Local gates
- cargo fmt --all -- --check
- cargo check --locked --all-targets
- cargo test --locked --all-targets --quiet
- .\\scripts\\security_audit.sh