### PR TITLE
Release desktop v2.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EVPoly Desktop Changelog
 
+## UI-v2.5.5 - 2026-07-02
+- Bumped desktop app/updater version to 2.5.5.
+- Repinned the bundled runtime sidecar to runtime `v2.5.5` (`dfebd4f`) with quarter-cent Polymarket tick-size support.
+
 ## UI-v2.5.2 - 2026-07-01
 - Bumped desktop app/updater version to 2.5.2.
 - Repinned the bundled runtime sidecar to runtime `v2.5.2` (`cdcd646`) with the final Endgame Polymarket price-band guard and longest-enabled-timeframe overlap handling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poly-desktop",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "poly-desktop",
-      "version": "2.5.4",
+      "version": "2.5.5",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poly-desktop",
   "private": true,
-  "version": "2.5.4",
+  "version": "2.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "evpoly-desktop"
-version = "2.5.4"
+version = "2.5.5"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evpoly-desktop"
-version = "2.5.4"
+version = "2.5.5"
 description = "EVPoly Desktop - Cross-platform trading bot manager"
 authors = ["Degenapetrader"]
 license = "SEE LICENSE"

--- a/src-tauri/sidecar-core.lock
+++ b/src-tauri/sidecar-core.lock
@@ -1,2 +1,2 @@
-CORE_REF=59bc2950e06d61125c893800393c6e71e254453d
+CORE_REF=dfebd4f21753a6e175dafd5c5b67b7449636fbd5
 CORE_REPO=https://github.com/Degenapetrader/EVPOLY.git

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EVPoly",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "identifier": "com.evpoly.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Release desktop updater version 2.5.5
- Repin bundled runtime sidecar to v2.5.5 runtime dfebd4f

## Local gates
- npm test
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --quiet