### PR TITLE
Release desktop v2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poly-desktop",
-  "version": "2.5.7",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "poly-desktop",
-      "version": "2.5.7",
+      "version": "2.6.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poly-desktop",
   "private": true,
-  "version": "2.5.7",
+  "version": "2.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "evpoly-desktop"
-version = "2.5.7"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evpoly-desktop"
-version = "2.5.7"
+version = "2.6.0"
 description = "EVPoly Desktop - Cross-platform trading bot manager"
 authors = ["Degenapetrader"]
 license = "SEE LICENSE"

--- a/src-tauri/sidecar-core.lock
+++ b/src-tauri/sidecar-core.lock
@@ -1,2 +1,2 @@
-CORE_REF=ffcc28a579e4eb808327320d467501032fe9e3f8
+CORE_REF=6c1056c8b6c8d8d1ae40c42e58281ef41bc424cd
 CORE_REPO=https://github.com/Degenapetrader/EVPOLY.git

--- a/src-tauri/src/config_io.rs
+++ b/src-tauri/src/config_io.rs
@@ -710,8 +710,8 @@ mod tests {
         let mut profile = sample_profile();
         profile.strategy_config = serde_json::json!({
             "EVPOLY_MM_SPORT_PAUSE_AFTER_FILL_SEC": 600.0,
-            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC": 90.0,
-            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC": 180.0,
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC": 185.0,
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC": 300.0,
             "EVPOLY_MM_AUTO_REFRESH_SEC": 300.0
         });
 
@@ -726,8 +726,8 @@ mod tests {
         let content = std::fs::read_to_string(&env_path).expect("read env");
 
         assert!(content.contains("EVPOLY_MM_SPORT_PAUSE_AFTER_FILL_SEC=600"));
-        assert!(content.contains("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC=90"));
-        assert!(content.contains("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC=180"));
+        assert!(content.contains("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC=185"));
+        assert!(content.contains("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC=300"));
         assert!(content.contains("EVPOLY_MM_AUTO_REFRESH_SEC=300"));
         assert!(!content.contains("EVPOLY_MM_SPORT_PAUSE_AFTER_FILL_SEC=600.0"));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -407,6 +407,13 @@ fn normalize_nonnegative_integer_f64(value: f64, default: f64) -> f64 {
     }
 }
 
+const POLYMARKET_GTD_MIN_EXPIRY_SECONDS: f64 = 185.0;
+const DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS: f64 = 300.0;
+
+fn normalize_gtd_expiry_seconds_f64(value: f64, default: f64) -> f64 {
+    normalize_nonnegative_integer_f64(value, default).max(POLYMARKET_GTD_MIN_EXPIRY_SECONDS)
+}
+
 fn normalize_utc_minute_f64(value: f64, default: f64) -> f64 {
     normalize_nonnegative_integer_f64(value, default).min(1439.0)
 }
@@ -764,6 +771,21 @@ fn default_desktop_config(eoa_wallet: String, proxy_wallet: String, sig_type: u8
         config_io::env_template_default_f64("EVPOLY_MM_SPORT_QUOTE_COOLDOWN_MIN_SEC", 10.0),
         config_io::env_template_default_f64("EVPOLY_MM_SPORT_QUOTE_COOLDOWN_MAX_SEC", 60.0),
     );
+    let quote_expiry_min_sec = normalize_gtd_expiry_seconds_f64(
+        config_io::env_template_default_f64(
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC",
+            POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+        ),
+        POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+    );
+    let quote_expiry_max_sec = normalize_gtd_expiry_seconds_f64(
+        config_io::env_template_default_f64(
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC",
+            DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
+        ),
+        DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
+    )
+    .max(quote_expiry_min_sec);
     let active_sport_market_cap = normalize_nonnegative_integer_f64(
         config_io::env_template_default_f64(
             "EVPOLY_MM_SPORT_ACTIVE_SPORT_MARKET_CAP",
@@ -1176,14 +1198,8 @@ fn default_desktop_config(eoa_wallet: String, proxy_wallet: String, sig_type: u8
                     "EVPOLY_MM_SPORT_SPONSORED_REWARD_MIN_SHARE",
                     0.50,
                 ),
-                quote_expiry_min_sec: config_io::env_template_default_f64(
-                    "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC",
-                    65.0,
-                ),
-                quote_expiry_max_sec: config_io::env_template_default_f64(
-                    "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC",
-                    185.0,
-                ),
+                quote_expiry_min_sec,
+                quote_expiry_max_sec,
                 quote_cooldown_min_sec,
                 quote_cooldown_max_sec,
                 fifo_max_share_ratio: config_io::env_template_default_f64(
@@ -2447,13 +2463,22 @@ fn desktop_config_to_profile_payload(
         "EVPOLY_MM_SPORT_SPONSORED_REWARD_MIN_SHARE".to_string(),
         number_to_json(config.strategy_settings.mm_sport.sponsored_reward_min_share),
     );
+    let quote_expiry_min_sec = normalize_gtd_expiry_seconds_f64(
+        config.strategy_settings.mm_sport.quote_expiry_min_sec,
+        POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+    );
+    let quote_expiry_max_sec = normalize_gtd_expiry_seconds_f64(
+        config.strategy_settings.mm_sport.quote_expiry_max_sec,
+        DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
+    )
+    .max(quote_expiry_min_sec);
     strategy.insert(
         "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC".to_string(),
-        number_to_json(config.strategy_settings.mm_sport.quote_expiry_min_sec),
+        number_to_json(quote_expiry_min_sec),
     );
     strategy.insert(
         "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC".to_string(),
-        number_to_json(config.strategy_settings.mm_sport.quote_expiry_max_sec),
+        number_to_json(quote_expiry_max_sec),
     );
     strategy.insert(
         "EVPOLY_MM_SPORT_QUOTE_COOLDOWN_MIN_SEC".to_string(),
@@ -2822,6 +2847,29 @@ fn profile_to_desktop_config(profile: &Profile, auth: &AppAuth) -> Result<Value,
         ),
         default_active_nonsport_market_cap,
     );
+    let mm_sport_quote_expiry_min_sec = normalize_gtd_expiry_seconds_f64(
+        f64_from_object(
+            &strategy,
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC",
+            config_io::env_template_default_f64(
+                "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC",
+                POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+            ),
+        ),
+        POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+    );
+    let mm_sport_quote_expiry_max_sec = normalize_gtd_expiry_seconds_f64(
+        f64_from_object(
+            &strategy,
+            "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC",
+            config_io::env_template_default_f64(
+                "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC",
+                DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
+            ),
+        ),
+        DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
+    )
+    .max(mm_sport_quote_expiry_min_sec);
 
     let relayer_remote_signer_token = secrets
         .get("EVPOLY_RELAYER_REMOTE_SIGNER_TOKEN")
@@ -3010,8 +3058,8 @@ fn profile_to_desktop_config(profile: &Profile, auth: &AppAuth) -> Result<Value,
                 "min_entry_top_bid_price": f64_from_object(&strategy, "EVPOLY_MM_SPORT_MIN_ENTRY_TOP_BID_PRICE", config_io::env_template_default_f64("EVPOLY_MM_SPORT_MIN_ENTRY_TOP_BID_PRICE", 0.05)),
                 "allow_sponsored_rewards": bool_from_object(&strategy, "EVPOLY_MM_SPORT_ALLOW_SPONSORED_REWARDS", config_io::env_template_default_bool("EVPOLY_MM_SPORT_ALLOW_SPONSORED_REWARDS", true)),
                 "sponsored_reward_min_share": f64_from_object(&strategy, "EVPOLY_MM_SPORT_SPONSORED_REWARD_MIN_SHARE", config_io::env_template_default_f64("EVPOLY_MM_SPORT_SPONSORED_REWARD_MIN_SHARE", 0.50)),
-                "quote_expiry_min_sec": f64_from_object(&strategy, "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC", config_io::env_template_default_f64("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MIN_SEC", 65.0)),
-                "quote_expiry_max_sec": f64_from_object(&strategy, "EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC", config_io::env_template_default_f64("EVPOLY_MM_SPORT_QUOTE_EXPIRY_MAX_SEC", 185.0)),
+                "quote_expiry_min_sec": mm_sport_quote_expiry_min_sec,
+                "quote_expiry_max_sec": mm_sport_quote_expiry_max_sec,
                 "quote_cooldown_min_sec": mm_sport_quote_cooldown_min_sec,
                 "quote_cooldown_max_sec": mm_sport_quote_cooldown_max_sec,
                 "fifo_max_share_ratio": f64_from_object(&strategy, "EVPOLY_MM_SPORT_FIFO_MAX_SHARE_RATIO", config_io::env_template_default_f64("EVPOLY_MM_SPORT_FIFO_MAX_SHARE_RATIO", 0.50)),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EVPoly",
-  "version": "2.5.7",
+  "version": "2.6.0",
   "identifier": "com.evpoly.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/StrategyEditorPane.tsx
+++ b/src/components/StrategyEditorPane.tsx
@@ -3,6 +3,7 @@ import { SectionPanel } from "./SectionPanel";
 import {
   mmSportRouteDefaultCaps,
   parseNonNegative,
+  POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
   premarketLadderPricesForMode,
   strategyCapValue,
   strategyLabel,
@@ -2172,11 +2173,32 @@ export function StrategyEditorPane({
             <div className="mm-quote-guard-card">
               <h4>Quote Lifetime</h4>
               <div className="mm-quote-grid mm-quote-grid--guard">
-                {renderNumberField("Quote Expiry Min", mmSport.quote_expiry_min_sec, (value) =>
-                  patchMMSport({ quote_expiry_min_sec: value })
+                {renderNumberField(
+                  "Quote Expiry Min",
+                  mmSport.quote_expiry_min_sec,
+                  (value) =>
+                    patchMMSport({
+                      quote_expiry_min_sec: Math.max(value, POLYMARKET_GTD_MIN_EXPIRY_SECONDS),
+                      quote_expiry_max_sec: Math.max(
+                        mmSport.quote_expiry_max_sec,
+                        value,
+                        POLYMARKET_GTD_MIN_EXPIRY_SECONDS
+                      ),
+                    }),
+                  { min: POLYMARKET_GTD_MIN_EXPIRY_SECONDS }
                 )}
-                {renderNumberField("Quote Expiry Max", mmSport.quote_expiry_max_sec, (value) =>
-                  patchMMSport({ quote_expiry_max_sec: value })
+                {renderNumberField(
+                  "Quote Expiry Max",
+                  mmSport.quote_expiry_max_sec,
+                  (value) =>
+                    patchMMSport({
+                      quote_expiry_max_sec: Math.max(
+                        value,
+                        mmSport.quote_expiry_min_sec,
+                        POLYMARKET_GTD_MIN_EXPIRY_SECONDS
+                      ),
+                    }),
+                  { min: POLYMARKET_GTD_MIN_EXPIRY_SECONDS }
                 )}
               </div>
             </div>

--- a/src/lib/desktop-config.test.ts
+++ b/src/lib/desktop-config.test.ts
@@ -77,6 +77,21 @@ describe("desktop config MM 2.0 sizing profiles", () => {
     expect(merged.strategy_settings.mm_sport.nonsport_entry_schedule_end_minute_utc).toBe(240);
   });
 
+  it("normalizes MM 2.0 quote expiry to Polymarket GTD minimums", () => {
+    const merged = mergeConfig({
+      strategy_settings: {
+        mm_sport: {
+          quote_expiry_min_sec: 90,
+          quote_expiry_max_sec: 180,
+        },
+      },
+    } as Partial<BotConfig>);
+
+    expect(merged.strategy_settings.mm_sport.quote_expiry_min_sec).toBe(185);
+    expect(merged.strategy_settings.mm_sport.quote_expiry_max_sec).toBe(185);
+    expect(mergeConfig(null).strategy_settings.mm_sport.quote_expiry_max_sec).toBe(300);
+  });
+
   it("normalizes MM 2.0 entry price mode", () => {
     expect(mergeConfig(null).strategy_settings.mm_sport.entry_price_mode).toBe("best_bid");
     expect(

--- a/src/lib/desktop-config.ts
+++ b/src/lib/desktop-config.ts
@@ -135,6 +135,13 @@ function normalizeNonNegativeInteger(value: number | undefined, fallback: number
   return Math.floor(value);
 }
 
+export const POLYMARKET_GTD_MIN_EXPIRY_SECONDS = 185;
+export const DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS = 300;
+
+function normalizeGtdExpirySeconds(value: number | undefined, fallback: number): number {
+  return Math.max(POLYMARKET_GTD_MIN_EXPIRY_SECONDS, normalizeNonNegativeInteger(value, fallback));
+}
+
 function normalizeUtcMinute(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return fallback;
   return Math.min(1439, Math.floor(value));
@@ -303,8 +310,8 @@ const DEFAULT_STRATEGY_SETTINGS: StrategySettings = {
     min_entry_top_bid_price: 0.05,
     allow_sponsored_rewards: true,
     sponsored_reward_min_share: 0.5,
-    quote_expiry_min_sec: 65,
-    quote_expiry_max_sec: 185,
+    quote_expiry_min_sec: POLYMARKET_GTD_MIN_EXPIRY_SECONDS,
+    quote_expiry_max_sec: DEFAULT_MM_SPORT_QUOTE_EXPIRY_MAX_SECONDS,
     quote_cooldown_min_sec: 10,
     quote_cooldown_max_sec: 60,
     fifo_max_share_ratio: 0.5,
@@ -408,6 +415,17 @@ export function mergeConfig(saved: Partial<BotConfig> | null | undefined): BotCo
     savedMmSport?.quote_cooldown_max_sec,
     DEFAULT_CONFIG.strategy_settings.mm_sport.quote_cooldown_min_sec,
     DEFAULT_CONFIG.strategy_settings.mm_sport.quote_cooldown_max_sec
+  );
+  const mmSportQuoteExpiryMin = normalizeGtdExpirySeconds(
+    savedMmSport?.quote_expiry_min_sec,
+    DEFAULT_CONFIG.strategy_settings.mm_sport.quote_expiry_min_sec
+  );
+  const mmSportQuoteExpiryMax = Math.max(
+    normalizeGtdExpirySeconds(
+      savedMmSport?.quote_expiry_max_sec,
+      DEFAULT_CONFIG.strategy_settings.mm_sport.quote_expiry_max_sec
+    ),
+    mmSportQuoteExpiryMin
   );
   const sportQuoteSizeMode = normalizeMMSportQuoteSizeMode(savedMmSport?.quote_size_mode);
   const sportQuoteSizeMultiplier =
@@ -566,6 +584,8 @@ export function mergeConfig(saved: Partial<BotConfig> | null | undefined): BotCo
           savedMmSport?.nonsport_min_top_depth_usd ?? sportMinTopDepthUsd,
         quote_cooldown_min_sec: mmSportCooldown.quote_cooldown_min_sec,
         quote_cooldown_max_sec: mmSportCooldown.quote_cooldown_max_sec,
+        quote_expiry_min_sec: mmSportQuoteExpiryMin,
+        quote_expiry_max_sec: mmSportQuoteExpiryMax,
         sport_entry_schedule_enabled:
           savedMmSport?.sport_entry_schedule_enabled ??
           savedMmSport?.nonsport_entry_schedule_enabled ??

--- a/src/lib/tauri-commands.test.ts
+++ b/src/lib/tauri-commands.test.ts
@@ -178,7 +178,7 @@ const SAMPLE_CONFIG: BotConfig = {
       min_entry_top_bid_price: 0.1,
       allow_sponsored_rewards: true,
       sponsored_reward_min_share: 0.5,
-      quote_expiry_min_sec: 180,
+      quote_expiry_min_sec: 185,
       quote_expiry_max_sec: 300,
       quote_cooldown_min_sec: 10,
       quote_cooldown_max_sec: 60,


### PR DESCRIPTION
## Summary
- Bump desktop app to v2.6.0
- Clamp MM Sport quote expiry UI/profile values to Polymarket 185s GTD minimum
- Repin sidecar runtime to main commit 6c1056c8b6c8d8d1ae40c42e58281ef41bc424cd

## Local verification
- npm test
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml --quiet