### PR TITLE
Release runtime v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # EVPoly Changelog
 
+## v2.6.1 - 2026-07-07
+- Bumped runtime version for the desktop/Linux updater release that fixes imported deposit-wallet start/restart handling.
+
 ## v2.5.7 - 2026-07-03
 - Fixed Endgame BUY submission sizing so share-mode orders keep the configured share quantity through the API submit path.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,7 +3344,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polymarket-arbitrage-bot"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-arbitrage-bot"
-version = "2.6.0"
+version = "2.6.1"
 edition = "2021"
 license-file = "LICENSE"
 default-run = "polymarket-arbitrage-bot"


### PR DESCRIPTION
Bumps the runtime package metadata to 2.6.1 for the desktop/Linux updater release.\n\nLocal gates run:\n- cargo fmt --all -- --check\n- cargo check --locked --all-targets\n- cargo test --locked --all-targets --quiet\n- ./scripts/security_audit.sh