### PR TITLE
Release runtime v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EVPoly Changelog
 
+## v2.6.2 - 2026-07-22
+- Accepted Polymarket market payloads with null or missing `tags`, preventing market deserialization failures.
+- Refreshed the runtime's patch-level Rust dependencies.
+
 ## v2.6.1 - 2026-07-07
 - Bumped runtime version for the desktop/Linux updater release that fixes imported deposit-wallet start/restart handling.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3353,7 +3353,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polymarket-arbitrage-bot"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polymarket-arbitrage-bot"
-version = "2.6.1"
+version = "2.6.2"
 edition = "2021"
 license-file = "LICENSE"
 default-run = "polymarket-arbitrage-bot"


### PR DESCRIPTION
## Summary
- bump the EVPOLY runtime to 2.6.2
- document the nullable/missing Polymarket market-tags fix
- include the patch-level dependency refresh already landed on main

## Verification
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `cargo test --locked --all-targets --quiet` (474 passed)
- `scripts/security_audit.sh`