### PR TITLE
Release desktop v2.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EVPoly Desktop Changelog
 
+## UI-v2.6.2 - 2026-07-22
+- Bumped desktop app/updater version to 2.6.2.
+- Repinned the bundled runtime sidecar to runtime `v2.6.2` (`10eb5b5`) with nullable/missing Polymarket market-tag handling and refreshed patch dependencies.
+
 ## UI-v2.6.1 - 2026-07-07
 - Bumped desktop app/updater version to 2.6.1.
 - Fixed imported sigType 3 deposit-wallet start/restart so Magic reconcile remains enabled only for Magic-created profiles.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "poly-desktop",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "poly-desktop",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1",
         "@tauri-apps/plugin-shell": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poly-desktop",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2338,7 +2338,7 @@ dependencies = [
 
 [[package]]
 name = "evpoly-desktop"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
  "aes-gcm",
  "alloy-primitives",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evpoly-desktop"
-version = "2.6.1"
+version = "2.6.2"
 description = "EVPoly Desktop - Cross-platform trading bot manager"
 authors = ["Degenapetrader"]
 license = "SEE LICENSE"

--- a/src-tauri/sidecar-core.lock
+++ b/src-tauri/sidecar-core.lock
@@ -1,2 +1,2 @@
-CORE_REF=1f586388b223f17c268db3a7e15685dda4dcf9df
+CORE_REF=10eb5b50fa143461b99e9d1c561a9935eb49dbc3
 CORE_REPO=https://github.com/Degenapetrader/EVPOLY.git

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "EVPoly",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "identifier": "com.evpoly.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- bump the Windows desktop app and updater to 2.6.2
- pin the bundled runtime sidecar to landed runtime commit `10eb5b50fa143461b99e9d1c561a9935eb49dbc3`
- document the runtime fix included in this updater release

## Verification
- `npm test` (32 passed)
- `npm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet` (57 passed)